### PR TITLE
feat: Add user roles to organizations

### DIFF
--- a/src/app/api/folders/[id]/route.ts
+++ b/src/app/api/folders/[id]/route.ts
@@ -41,7 +41,7 @@ export async function DELETE(request: Request, { params }: { params: { id: strin
   try {
     const { id } = params;
 
-    const deleteFolderAndContents = (folderId: number) => {
+    const deleteFolderAndContents = (folderId: number | bigint) => {
       const subfolders = db.prepare('SELECT id FROM folders WHERE parent_folder_id = ?').all(folderId) as Pick<Folder, 'id'>[];
       for (const subfolder of subfolders) {
         deleteFolderAndContents(subfolder.id);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -6,7 +6,10 @@ db.exec(`
   CREATE TABLE IF NOT EXISTS users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL,
-    email TEXT NOT NULL UNIQUE
+    email TEXT NOT NULL UNIQUE,
+    organization_id INTEGER,
+    role TEXT NOT NULL DEFAULT 'member' CHECK(role IN ('admin', 'coadmin', 'member', 'limited member')),
+    FOREIGN KEY (organization_id) REFERENCES organizations(id)
   );
 `);
 

--- a/src/lib/init-db.ts
+++ b/src/lib/init-db.ts
@@ -20,6 +20,7 @@ function initDb() {
       name TEXT NOT NULL,
       email TEXT NOT NULL UNIQUE,
       organization_id INTEGER,
+      role TEXT NOT NULL DEFAULT 'member' CHECK(role IN ('admin', 'coadmin', 'member', 'limited member')),
       FOREIGN KEY (organization_id) REFERENCES organizations(id)
     );
 
@@ -73,9 +74,9 @@ function initDb() {
     updateOrgStmt.run(rootFolderId, orgId);
 
     const userStmt = db.prepare(`
-      INSERT INTO users (name, email, organization_id) VALUES (?, ?, ?)
+      INSERT INTO users (name, email, organization_id, role) VALUES (?, ?, ?, ?)
     `);
-    userStmt.run('Default User', 'user@example.com', orgId);
+    userStmt.run('Default User', 'user@example.com', orgId, 'admin');
 
     console.log('Default data created successfully.');
   } catch (e) {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -4,11 +4,14 @@ export interface Organization {
   root_folder_id: number;
 }
 
+export type UserRole = 'admin' | 'coadmin' | 'member' | 'limited member';
+
 export interface User {
   id: number;
   name: string;
   email: string;
   organization_id: number;
+  role: UserRole;
 }
 
 export interface Group {


### PR DESCRIPTION
This commit introduces a role-based access control system for users within an organization.

- Adds a `role` column to the `users` table with possible values: 'admin', 'coadmin', 'member', 'limited member'.
- Updates the `User` interface in `src/lib/schema.ts` to include the new `role` property.
- Sets the default user's role to 'admin' in the database initialization script.
- Installs `ts-node` to support running the database initialization script.
- Addresses code review feedback by restoring the `bigint` type to the `deleteFolderAndContents` function signature for better type consistency.