### PR TITLE
feat: Add member role management in organization tab

### DIFF
--- a/dev.log
+++ b/dev.log
@@ -1,9 +1,0 @@
-
-> kahoot-manager@0.1.0 dev
-> next dev
-
-   ▲ Next.js 15.5.4
-   - Local:        http://localhost:3000
-   - Network:      http://192.168.0.2:3000
-
- ✓ Starting...

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,13 +1,15 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, NextRequest } from 'next/server';
 import db from '@/lib/db';
 
-export async function GET(request: Request, { params }: { params: { id: string } }) {
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const { id } = params;
     const user = db.prepare('SELECT * FROM users WHERE id = ?').get(id);
+
     if (!user) {
       return NextResponse.json({ message: 'User not found' }, { status: 404 });
     }
+
     return NextResponse.json(user);
   } catch (error) {
     console.error(error);
@@ -15,33 +17,82 @@ export async function GET(request: Request, { params }: { params: { id: string }
   }
 }
 
-export async function PUT(request: Request, { params }: { params: { id: string } }) {
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const { id } = params;
-    const { name, email } = await request.json();
-    if (!name || !email) {
-      return NextResponse.json({ message: 'Name and email are required' }, { status: 400 });
+    const { role, currentUserId } = await request.json();
+
+    if (!role || !currentUserId) {
+      return NextResponse.json({ message: 'Role and currentUserId are required' }, { status: 400 });
     }
-    const stmt = db.prepare('UPDATE users SET name = ?, email = ? WHERE id = ?');
-    const info = stmt.run(name, email, id);
+
+    const currentUser = db.prepare('SELECT * FROM users WHERE id = ?').get(currentUserId);
+    const targetUser = db.prepare('SELECT * FROM users WHERE id = ?').get(id);
+
+    if (!currentUser || !targetUser) {
+      return NextResponse.json({ message: 'User not found' }, { status: 404 });
+    }
+
+    if (currentUser.organization_id !== targetUser.organization_id) {
+      return NextResponse.json({ message: 'Forbidden' }, { status: 403 });
+    }
+
+    if (currentUser.role !== 'admin' && currentUser.role !== 'coadmin') {
+      return NextResponse.json({ message: 'Forbidden' }, { status: 403 });
+    }
+
+    const allowedRoles = ['admin', 'coadmin', 'member', 'limited member'];
+    if (!allowedRoles.includes(role)) {
+      return NextResponse.json({ message: 'Invalid role' }, { status: 400 });
+    }
+
+    const stmt = db.prepare('UPDATE users SET role = ? WHERE id = ?');
+    const info = stmt.run(role, id);
+
     if (info.changes === 0) {
       return NextResponse.json({ message: 'User not found' }, { status: 404 });
     }
-    return NextResponse.json({ id, name, email });
+
+    return NextResponse.json({ message: 'User role updated successfully' });
   } catch (error) {
     console.error(error);
     return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 });
   }
 }
 
-export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const { id } = params;
+    const { name, email } = await request.json();
+
+    if (!name || !email) {
+      return NextResponse.json({ message: 'Name and email are required' }, { status: 400 });
+    }
+
+    const stmt = db.prepare('UPDATE users SET name = ?, email = ? WHERE id = ?');
+    const info = stmt.run(name, email, id);
+
+    if (info.changes === 0) {
+      return NextResponse.json({ message: 'User not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ message: 'User updated successfully' });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const { id } = params;
     const stmt = db.prepare('DELETE FROM users WHERE id = ?');
     const info = stmt.run(id);
+
     if (info.changes === 0) {
       return NextResponse.json({ message: 'User not found' }, { status: 404 });
     }
+
     return NextResponse.json({ message: 'User deleted successfully' });
   } catch (error) {
     console.error(error);

--- a/src/components/OrganizationsTab.tsx
+++ b/src/components/OrganizationsTab.tsx
@@ -9,8 +9,16 @@ interface Organization {
   root_folder_id: number;
 }
 
+interface User {
+  id: number;
+  name: string;
+  email: string;
+  role: 'admin' | 'coadmin' | 'member' | 'limited member';
+}
+
 const OrganizationsTab = () => {
   const [organizations, setOrganizations] = useState<Organization[]>([]);
+  const [usersByOrg, setUsersByOrg] = useState<Record<number, User[]>>({});
   const [name, setName] = useState('');
   const [editingOrg, setEditingOrg] = useState<Organization | null>(null);
   const { currentUser, refetchUsers } = useUser();
@@ -21,9 +29,21 @@ const OrganizationsTab = () => {
       const res = await fetch(`/api/organizations?userId=${currentUser.id}`);
       const data = await res.json();
       setOrganizations(data);
+      if (data.length > 0) {
+        // Fetch users for all organizations
+        data.forEach((org: Organization) => fetchUsers(org.id));
+      }
     } else {
       setOrganizations([]);
+      setUsersByOrg({});
     }
+  };
+
+  const fetchUsers = async (organizationId: number) => {
+    if (!currentUser) return;
+    const res = await fetch(`/api/users?organizationId=${organizationId}&currentUserId=${currentUser.id}`);
+    const data = await res.json();
+    setUsersByOrg((prev) => ({ ...prev, [organizationId]: data }));
   };
 
   useEffect(() => {
@@ -69,6 +89,16 @@ const OrganizationsTab = () => {
     fetchOrganizations();
   };
 
+  const handleRoleChange = async (userId: number, role: string, organizationId: number) => {
+    if (!currentUser) return;
+    await fetch(`/api/users/${userId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ role, currentUserId: currentUser.id }),
+    });
+    fetchUsers(organizationId);
+  };
+
   const resetForm = () => {
     setEditingOrg(null);
     setName('');
@@ -97,20 +127,43 @@ const OrganizationsTab = () => {
       )}
 
       <div>
-        <h2 className="text-2xl font-bold text-gray-800 mb-4">Current Organization</h2>
+        <h2 className="text-2xl font-bold text-gray-800 mb-4">Organizations</h2>
         {currentUser ? (
           organizations.length > 0 ? (
-            <ul className="space-y-3">
+            <div className="space-y-6">
               {organizations.map((org) => (
-                <li key={org.id} className="flex justify-between items-center p-4 bg-white rounded-lg shadow-md hover:shadow-lg transition">
-                  <p className="font-semibold text-gray-700">{org.name}</p>
-                  <div className="flex space-x-2">
-                    <button onClick={() => handleEdit(org)} className="px-4 py-2 bg-yellow-500 text-white font-semibold rounded-lg hover:bg-yellow-600 transition">Edit</button>
-                    <button onClick={() => handleDelete(org.id)} className="px-4 py-2 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 transition">Delete</button>
+                <div key={org.id} className="p-4 bg-white rounded-lg shadow-md">
+                  <div className="flex justify-between items-center mb-4">
+                    <h3 className="text-xl font-bold text-gray-800">{org.name}</h3>
+                    <div className="flex space-x-2">
+                      <button onClick={() => handleEdit(org)} className="px-4 py-2 bg-yellow-500 text-white font-semibold rounded-lg hover:bg-yellow-600 transition">Edit</button>
+                      <button onClick={() => handleDelete(org.id)} className="px-4 py-2 bg-red-600 text-white font-semibold rounded-lg hover:bg-red-700 transition">Delete</button>
+                    </div>
                   </div>
-                </li>
+                  <h4 className="text-lg font-semibold text-gray-700 mb-2">Members</h4>
+                  <ul className="space-y-3">
+                    {(usersByOrg[org.id] || []).map((user) => (
+                      <li key={user.id} className="flex justify-between items-center p-2 bg-gray-50 rounded-lg">
+                        <div>
+                          <p className="font-semibold text-gray-700">{user.name}</p>
+                          <p className="text-sm text-gray-500">{user.email}</p>
+                        </div>
+                        <select
+                          value={user.role}
+                          onChange={(e) => handleRoleChange(user.id, e.target.value, org.id)}
+                          className="border border-gray-300 p-2 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition"
+                        >
+                          <option value="admin">Admin</option>
+                          <option value="coadmin">Coadmin</option>
+                          <option value="member">Member</option>
+                          <option value="limited member">Limited Member</option>
+                        </select>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               ))}
-            </ul>
+            </div>
           ) : (
             <div>
               <p className="text-gray-500 mb-4">No organization associated with this user. Create one below.</p>


### PR DESCRIPTION
This commit introduces the ability for administrators to manage member roles within the organization tab.

- Adds a list of all members in the organization tab.
- Allows admins and coadmins to change the role of a member to one of 'admin', 'coadmin', 'member', or 'limited member'.
- Implements authorization checks on the API to ensure that only privileged users can perform these actions.