### PR TITLE
feat: Add and remove users from organizations

### DIFF
--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -20,10 +20,10 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
 export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const { id } = params;
-    const { role, currentUserId } = await request.json();
+    const { role, organization_id, currentUserId } = await request.json();
 
-    if (!role || !currentUserId) {
-      return NextResponse.json({ message: 'Role and currentUserId are required' }, { status: 400 });
+    if (!currentUserId) {
+      return NextResponse.json({ message: 'currentUserId is required' }, { status: 400 });
     }
 
     const currentUser = db.prepare('SELECT * FROM users WHERE id = ?').get(currentUserId);
@@ -33,27 +33,39 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
       return NextResponse.json({ message: 'User not found' }, { status: 404 });
     }
 
-    if (currentUser.organization_id !== targetUser.organization_id) {
-      return NextResponse.json({ message: 'Forbidden' }, { status: 403 });
-    }
-
     if (currentUser.role !== 'admin' && currentUser.role !== 'coadmin') {
-      return NextResponse.json({ message: 'Forbidden' }, { status: 403 });
+      return NextResponse.json({ message: 'Forbidden: only admins or co-admins can perform this action' }, { status: 403 });
     }
 
-    const allowedRoles = ['admin', 'coadmin', 'member', 'limited member'];
-    if (!allowedRoles.includes(role)) {
-      return NextResponse.json({ message: 'Invalid role' }, { status: 400 });
+    if (organization_id !== undefined) {
+      const orgToAuthorize = organization_id !== null ? organization_id : targetUser.organization_id;
+      if (currentUser.organization_id !== orgToAuthorize) {
+        return NextResponse.json({ message: 'Forbidden: You can only manage users in your own organization.' }, { status: 403 });
+      }
+
+      const stmt = db.prepare('UPDATE users SET organization_id = ? WHERE id = ?');
+      stmt.run(organization_id, id);
+
+      return NextResponse.json({ message: 'User organization updated successfully' });
     }
 
-    const stmt = db.prepare('UPDATE users SET role = ? WHERE id = ?');
-    const info = stmt.run(role, id);
+    if (role) {
+      if (currentUser.organization_id !== targetUser.organization_id) {
+        return NextResponse.json({ message: 'Forbidden: Cannot change roles for users in other organizations' }, { status: 403 });
+      }
 
-    if (info.changes === 0) {
-      return NextResponse.json({ message: 'User not found' }, { status: 404 });
+      const allowedRoles = ['admin', 'coadmin', 'member', 'limited member'];
+      if (!allowedRoles.includes(role)) {
+        return NextResponse.json({ message: 'Invalid role' }, { status: 400 });
+      }
+
+      const stmt = db.prepare('UPDATE users SET role = ? WHERE id = ?');
+      stmt.run(role, id);
+
+      return NextResponse.json({ message: 'User role updated successfully' });
     }
 
-    return NextResponse.json({ message: 'User role updated successfully' });
+    return NextResponse.json({ message: 'Either role or organization_id must be provided' }, { status: 400 });
   } catch (error) {
     console.error(error);
     return NextResponse.json({ message: 'Internal Server Error' }, { status: 500 });

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -6,6 +6,12 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const organizationId = searchParams.get('organizationId');
     const currentUserId = searchParams.get('currentUserId');
+    const unassigned = searchParams.get('unassigned');
+
+    if (unassigned === 'true') {
+      const users = db.prepare('SELECT * FROM users WHERE organization_id IS NULL').all();
+      return NextResponse.json(users);
+    }
 
     if (organizationId) {
       if (!currentUserId) {


### PR DESCRIPTION
This commit introduces the ability for administrators and co-administrators to manage organization membership from the "Organizations" tab.

Key changes include:
- A new API endpoint to fetch users who are not currently assigned to any organization.
- Updates to the user API to allow changing a user's `organization_id`, effectively adding or removing them from an organization.
- New UI elements in the `OrganizationsTab` component, including an "Add Member" button with a user selection dropdown and a "Remove" button for existing members.